### PR TITLE
Remove libfmt

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,6 @@ cpp = meson.get_compiler('cpp')
 
 buildtype = get_option('buildtype')
 
-fmt = dependency('fmt')
 spdlog = dependency('spdlog')
 vulkan = dependency('vulkan')
 # fontconfig = dependency('Fontconfig')
@@ -25,9 +24,14 @@ toml = dependency('tomlplusplus')
 # json = dependency('nlohmann_json')
 
 add_project_arguments(
+    # vulkan-hpp configuration
     '-DVULKAN_HPP_NO_EXCEPTIONS',
     '-DVUKLAN_HPP_ASSERT_ON_RESULT(x)',
     '-DVULKAN_HPP_DISPATCH_LOADER_DYNAMIC=1',
+
+    # spdlog configuration
+    '-DSPDLOG_USE_STD_FORMAT',
+    
     language: 'cpp',
 )
 

--- a/wren/src/scene/serialization.cpp
+++ b/wren/src/scene/serialization.cpp
@@ -2,6 +2,7 @@
 
 #include <spdlog/spdlog.h>
 
+#include <fstream>
 #include <toml++/toml.hpp>
 
 #include "scene/components/mesh.hpp"

--- a/wren_utils/include/wren/utils/result.hpp
+++ b/wren_utils/include/wren/utils/result.hpp
@@ -1,12 +1,9 @@
 #pragma once
 
-#include <fmt/core.h>
-#include <fmt/format.h>
-#include <fmt/ostream.h>
-
 #include <boost/describe.hpp>
 #include <boost/preprocessor.hpp>
 #include <expected>
+#include <format>
 #include <optional>
 #include <system_error>
 
@@ -51,8 +48,8 @@ using expected = std::expected<T, Err>;
 }  // namespace wren
 
 template <>
-struct fmt::formatter<wren::Err> : fmt::formatter<std::string> {
-  auto format(wren::Err, fmt::format_context& ctx) const -> decltype(ctx.out());
+struct std::formatter<wren::Err> : std::formatter<std::string> {
+  auto format(wren::Err, std::format_context& ctx) const -> decltype(ctx.out());
 };
 
 //! @brief This macro creates the hooks into std::error_code for a

--- a/wren_utils/meson.build
+++ b/wren_utils/meson.build
@@ -1,16 +1,16 @@
 utils = library(
     'wren_utils',
     files(
-        'src/result.cpp',
         'src/filesystem.cpp',
+        'src/result.cpp',
         'src/string.cpp',
         'src/string_reader.cpp',
     ),
     include_directories: ['include', 'include/wren/utils'],
-    dependencies: [fmt, boost],
+    dependencies: [boost],
 )
 wren_utils_dep = declare_dependency(
     include_directories: 'include',
-    dependencies: [fmt, boost],
+    dependencies: [boost],
     link_with: utils,
 )

--- a/wren_utils/src/filesystem.cpp
+++ b/wren_utils/src/filesystem.cpp
@@ -1,6 +1,7 @@
 #include "filesystem.hpp"
 
 #include "result.hpp"
+#include <fstream>
 
 namespace wren::utils::fs {
 

--- a/wren_utils/src/result.cpp
+++ b/wren_utils/src/result.cpp
@@ -1,21 +1,19 @@
 #include "result.hpp"
 
-#include <fmt/format.h>
-
 #include <sstream>
 
 namespace wren {}  // namespace wren
 
-auto fmt::formatter<wren::Err>::format(wren::Err e,
-                                       fmt::format_context& ctx) const
+auto std::formatter<wren::Err>::format(wren::Err e,
+                                       std::format_context& ctx) const
     -> decltype(ctx.out()) {
   std::stringstream ss;
-  std::string fmt = fmt::format("Error: {} {}", e.error().category().name(),
+  std::string fmt = std::format("Error: {} {}", e.error().category().name(),
                                 e.error().message());
 
   ss << fmt;
   if (e.extra_msg().has_value()) {
     ss << "(" << e.extra_msg().value() << ")";
   }
-  return fmt::formatter<std::string>::format(ss.str(), ctx);
+  return std::formatter<std::string>::format(ss.str(), ctx);
 }


### PR DESCRIPTION
Replace the use of libfmt with the `std::format`, requires setting spdlog to use `std::format` insteaad

Fixes #37 