### PR TITLE
Simplified the render graph build API

### DIFF
--- a/editor/src/editor.cpp
+++ b/editor/src/editor.cpp
@@ -44,7 +44,7 @@ auto Editor::create(const std::shared_ptr<wren::Application> &app,
                  app->context()->graphics_context->Device().get(), asset_path));
 
   TRY_RESULT(const auto graph, editor->build_render_graph(app->context()));
-  app->context()->renderer->set_graph_builder(graph);
+  TRY_RESULT(graph.build());
 
   editor::ui::init(app->context());
 

--- a/wren/include/wren/graph.hpp
+++ b/wren/include/wren/graph.hpp
@@ -39,8 +39,14 @@ class GraphBuilder {
  public:
   explicit GraphBuilder(const std::shared_ptr<Context> &ctx) : ctx_(ctx) {}
 
+  /**
+    @brief This calls compile() and then assigns the graph to the renderer
+  */
   [[nodiscard]] auto build() const -> expected<void>;
 
+  /**
+    @brief Compiles the builder into an actual graph, it creates missing resources for targets and binds targets to the swapchain
+  */
   [[nodiscard]] auto compile() const -> expected<Graph>;
 
   auto add_pass(const std::string &name, const PassResources &resources,

--- a/wren/include/wren/graph.hpp
+++ b/wren/include/wren/graph.hpp
@@ -39,6 +39,8 @@ class GraphBuilder {
  public:
   explicit GraphBuilder(const std::shared_ptr<Context> &ctx) : ctx_(ctx) {}
 
+  [[nodiscard]] auto build() const -> expected<void>;
+
   [[nodiscard]] auto compile() const -> expected<Graph>;
 
   auto add_pass(const std::string &name, const PassResources &resources,

--- a/wren/include/wren/renderer.hpp
+++ b/wren/include/wren/renderer.hpp
@@ -24,10 +24,8 @@ class Renderer {
 
   void draw();
 
-  auto set_graph_builder(const GraphBuilder &builder) {
-    render_graph = builder.compile().value();
-  }
-  auto get_graph() const { return render_graph; }
+  auto set_graph(const Graph &graph) { render_graph_ = graph; }
+  auto get_graph() const { return render_graph_; }
 
   auto swapchain_images_views() const { return swapchain_image_views_; }
 
@@ -79,7 +77,7 @@ class Renderer {
   ::vk::CommandPool command_pool_;
   ::vk::CommandBuffer one_time_cmd_buffer;
 
-  Graph render_graph;
+  Graph render_graph_;
 
   Mesh m;
 };

--- a/wren/src/graph.cpp
+++ b/wren/src/graph.cpp
@@ -16,6 +16,14 @@ auto GraphBuilder::add_pass(const std::string &name,
   return *this;
 }
 
+auto GraphBuilder::build() const -> expected<void> {
+  TRY_RESULT(auto graph, compile());
+
+  ctx_->renderer->set_graph(graph);
+
+  return {};
+}
+
 auto GraphBuilder::compile() const -> expected<Graph> {
   Graph graph;
 

--- a/wren/src/renderer.cpp
+++ b/wren/src/renderer.cpp
@@ -59,7 +59,7 @@ void Renderer::end_frame(uint32_t image_index) {
       ::vk::PipelineStageFlagBits::eColorAttachmentOutput;
 
   std::vector<::vk::CommandBuffer> cmd_bufs;
-  for (auto g : render_graph) {
+  for (auto g : render_graph_) {
     ZoneScopedN("render_pass->execute()");
     g->render_pass->execute();
     const auto bufs = g->render_pass->get_command_buffers();
@@ -119,7 +119,7 @@ Renderer::Renderer(const std::shared_ptr<Context> &ctx)
         recreate_swapchain();
 
         // Resize the 'swapchain_target' render pass and it's targets
-        for (const auto &n : render_graph) {
+        for (const auto &n : render_graph_) {
           if (n->render_pass->resources().target_prefix() ==
               "swapchain_target") {
             n->render_pass->resize_target({w.width, w.height});
@@ -289,7 +289,7 @@ auto Renderer::recreate_swapchain() -> expected<void> {
     target->view(swapchain_image_views_.front());
   }
 
-  for (const auto &g : render_graph)
+  for (const auto &g : render_graph_)
     g->render_pass->recreate_framebuffers(
         ctx_->graphics_context->Device().get());
 


### PR DESCRIPTION
closes #62 can call `builder.build()` on the graph builder now